### PR TITLE
Add keyword indexer for concept-based Talmud page analysis

### DIFF
--- a/data/KEYWORD_INDEXER.md
+++ b/data/KEYWORD_INDEXER.md
@@ -1,0 +1,95 @@
+# Talmud Keyword Indexer
+
+A focused tool for creating page-level keyword indexes of the Babylonian Talmud based on conceptual gazetteers.
+
+## Overview
+
+This indexer complements the main NLP pipeline by providing a lightweight, frequency-based keyword extraction system. It processes the Steinsaltz Talmud text and generates a searchable index mapping each page to its most frequently mentioned concepts from the `talmud_concepts_gazetteer.txt`.
+
+## Files
+
+- **`create_talmud_index.py`** - Python script that generates the keyword index
+- **`talmud_index_final.csv`** - Output index with three columns: location, keywords, sefaria_link
+- **`steinsaltz_talmud_combined_richHTML.csv`** - Source data (Steinsaltz Talmud with HTML formatting)
+- **`talmud_concepts_gazetteer.txt`** - 182 Jewish theological and legal concepts used for matching
+
+## Technical Approach
+
+### Processing Pipeline
+
+1. **Concept Loading**: Loads 182 unique concepts from the gazetteer
+2. **Text Preprocessing**:
+   - Strips HTML tags from Talmud text
+   - Unescapes HTML entities for accurate matching
+   - Handles multiple character encodings (UTF-8, Latin-1, CP1252)
+3. **Keyword Matching**:
+   - Uses regex pattern matching with case-insensitive search
+   - Sorts concepts by length (longest first) to prioritize multi-word phrases
+   - Aggregates mentions across all sub-sections within each page
+4. **Frequency Analysis**: Counts keyword occurrences per page and sorts by frequency
+5. **Output Generation**: Creates CSV with page references, sorted keywords, and Sefaria links
+
+### Sorting Algorithm
+
+Custom sorting function handles Talmud page notation:
+- Extracts tractate name, page number, and side (a/b)
+- Sorts numerically by page, then alphabetically by side
+- Example: `Berakhot 2a → 2b → 3a → 3b`
+
+## Output Format
+
+The index (`talmud_index_final.csv`) contains three columns:
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| `location` | Tractate and page reference | `Berakhot 2a` |
+| `keywords` | Comma-separated concepts, sorted by frequency | `shema, sin, teruma, priest, torah` |
+| `sefaria_link` | Direct link to page on Sefaria | `https://www.sefaria.org.il/Berakhot.2a` |
+
+## Usage
+
+From the `data/` directory:
+
+```bash
+python create_talmud_index.py
+```
+
+This will:
+1. Load concepts from `talmud_concepts_gazetteer.txt`
+2. Process first 1,000 rows from `steinsaltz_talmud_combined_richHTML.csv`
+3. Generate `talmud_index_final.csv` with sorted, aggregated results
+
+## Statistics
+
+- **Pages Indexed**: 41 pages (Berakhot 2a through 22a)
+- **Source Rows Processed**: 1,000 text segments
+- **Concepts Identified**: 182 unique terms
+- **Average Keywords per Page**: ~12 unique concepts
+
+## Example Results
+
+**Berakhot 2a** (13 unique keywords, 87 total occurrences):
+- Most frequent: shema, sin, teruma, priest, torah, mitzva, mitzvot
+- Link: https://www.sefaria.org.il/Berakhot.2a
+
+**Berakhot 7a** (18 unique keywords, 124 total occurrences):
+- Most frequent: righteous, anger, wicked, exodus, mercy, sin
+- Link: https://www.sefaria.org.il/Berakhot.7a
+
+## Requirements
+
+- Python 3.x
+- Standard library only (csv, re, collections, html)
+- No external dependencies required
+
+## Differences from Main NLP Pipeline
+
+This keyword indexer differs from the main project's NLP pipeline:
+
+- **Lighter weight**: No ML models or embeddings required
+- **Concept-focused**: Uses only the concepts gazetteer, not names/places
+- **Frequency-based**: Simple count-based ranking vs. sophisticated NER tagging
+- **Page-level aggregation**: Combines all sub-sections into single page entries
+- **Direct Sefaria integration**: Includes clickable links in output
+
+Use this tool when you need quick concept frequency analysis across Talmud pages without running the full NLP pipeline.

--- a/data/create_talmud_index.py
+++ b/data/create_talmud_index.py
@@ -1,0 +1,118 @@
+import csv
+import re
+from collections import Counter
+from html import unescape
+
+# Load concepts gazetteer
+concepts = []
+with open('talmud_concepts_gazetteer.txt', 'r', encoding='utf-8') as f:
+    for line in f:
+        concept = line.strip()
+        if concept:  # Skip empty lines
+            concepts.append(concept)
+
+print(f"Loaded {len(concepts)} concepts from gazetteer")
+
+# Create regex pattern for case-insensitive matching
+# Escape special regex characters and sort by length (longest first) to match longer phrases first
+concepts_sorted = sorted(concepts, key=len, reverse=True)
+pattern = '|'.join(re.escape(concept) for concept in concepts_sorted)
+concept_regex = re.compile(pattern, re.IGNORECASE)
+
+# Process Talmud CSV
+page_keywords = {}  # Dictionary to store keywords by page
+# Try different encodings
+encodings = ['utf-8', 'latin-1', 'cp1252', 'iso-8859-1']
+for encoding in encodings:
+    try:
+        with open('steinsaltz_talmud_combined_richHTML.csv', 'r', encoding=encoding) as f:
+            reader = csv.DictReader(f)
+            # Test read first row
+            next(reader)
+        print(f"Successfully opened file with {encoding} encoding")
+        break
+    except (UnicodeDecodeError, StopIteration):
+        continue
+
+with open('steinsaltz_talmud_combined_richHTML.csv', 'r', encoding=encoding) as f:
+    reader = csv.DictReader(f)
+
+    for row_num, row in enumerate(reader, start=1):
+        if row_num > 1000:  # Limit to first 1000 rows
+            break
+
+        location = row['Column1']
+        text = row['Column2']
+
+        # Extract page number (e.g., "Berakhot 2a:1" -> "Berakhot 2a")
+        if ':' in location:
+            page = location.rsplit(':', 1)[0]
+        else:
+            page = location
+
+        # Remove HTML tags and unescape HTML entities
+        text_clean = re.sub(r'<[^>]+>', '', text)
+        text_clean = unescape(text_clean)
+
+        # Find all concept matches (case-insensitive)
+        matches = concept_regex.findall(text_clean)
+
+        if matches:
+            # Initialize page in dictionary if not exists
+            if page not in page_keywords:
+                page_keywords[page] = Counter()
+
+            # Add matches to this page's counter
+            for match in matches:
+                page_keywords[page][match.lower()] += 1
+
+            print(f"Row {row_num}: {location} (page: {page}) - Found {len(matches)} keyword instances")
+        else:
+            print(f"Row {row_num}: {location} (page: {page}) - No keywords found")
+
+# Custom sort function for Talmud pages
+def sort_talmud_page(page):
+    """Sort Talmud pages correctly (e.g., 2a before 2b before 3a)"""
+    import re
+    match = re.match(r'(.+?)\s+(\d+)([ab])', page)
+    if match:
+        tractate, page_num, side = match.groups()
+        return (tractate, int(page_num), side)
+    return (page, 0, 'a')
+
+# Convert to results list sorted correctly
+results = []
+for page in sorted(page_keywords.keys(), key=sort_talmud_page):
+    keyword_counts = page_keywords[page]
+
+    # Sort by count (descending)
+    sorted_keywords = sorted(keyword_counts.items(), key=lambda x: x[1], reverse=True)
+
+    # Create comma-separated list of keywords (without counts)
+    keywords_str = ', '.join(keyword for keyword, count in sorted_keywords)
+
+    # Create Sefaria link (format: https://www.sefaria.org.il/Tractate.PageSide)
+    # e.g., "Berakhot 2a" -> "https://www.sefaria.org.il/Berakhot.2a"
+    sefaria_link = f"https://www.sefaria.org.il/{page.replace(' ', '.')}"
+
+    results.append({
+        'location': page,
+        'keywords': keywords_str,
+        'sefaria_link': sefaria_link
+    })
+
+    print(f"\nPage {page}: {len(keyword_counts)} unique keywords, {sum(keyword_counts.values())} total occurrences")
+
+# Write results to CSV
+output_file = 'talmud_index_final.csv'
+try:
+    with open(output_file, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=['location', 'keywords', 'sefaria_link'])
+        writer.writeheader()
+        writer.writerows(results)
+    print(f"Output written to: {output_file}")
+except PermissionError:
+    print(f"Warning: Could not write to {output_file} - file may be open. Close it and try again.")
+
+print(f"\nCompleted! Created index with {len(results)} entries")
+print(f"Output written to: {output_file}")

--- a/data/talmud_index_final.csv
+++ b/data/talmud_index_final.csv
@@ -1,0 +1,42 @@
+location,keywords,sefaria_link
+Berakhot 2a,"shema, sin, teruma, priest, torah, mitzva, mitzvot, burnt offering, creation, sin-offering, guilt-offering, torah law, impurity",https://www.sefaria.org.il/Berakhot.2a
+Berakhot 2b,"priest, shema, teruma, sin, shabbat, torah",https://www.sefaria.org.il/Berakhot.2b
+Berakhot 3a,"shema, prayer, priest, teruma, shabbat, the temple, sin, temple, destruction of the temple, mil",https://www.sefaria.org.il/Berakhot.3a
+Berakhot 3b,"sin, torah, nasi, anger, righteous, shema, aramaic, exodus, parable, sanhedrin",https://www.sefaria.org.il/Berakhot.3b
+Berakhot 4a,"sanhedrin, sin, mil, torah, impurity, righteous, shema, priest, torah study, prayer, creation, world-to-come, exodus, the exile",https://www.sefaria.org.il/Berakhot.4a
+Berakhot 4b,"prayer, shema, sin, mitzva, world-to-come, creation, torah, rabbinic, exodus, mil",https://www.sefaria.org.il/Berakhot.4b
+Berakhot 5a,"torah, shema, sin, prayer, mitzva, torah study, world-to-come, exodus, mitzvot, righteous, guilt-offering, meal-offering",https://www.sefaria.org.il/Berakhot.5a
+Berakhot 5b,"prayer, leprosy, mercy, torah, impurity, sin, mil, divine presence, shema, the temple",https://www.sefaria.org.il/Berakhot.5b
+Berakhot 6a,"sin, divine presence, phylacteries, prayer, torah, torah study, judgment, mitzva, mil, righteous, the temple, mitzvot, mercy, exodus",https://www.sefaria.org.il/Berakhot.6a
+Berakhot 6b,"prayer, sin, shofar, mil, shabbat, wicked, mitzva, torah, thanks-offering, exodus, phylacteries, the temple, mitzvot, incense, mercy",https://www.sefaria.org.il/Berakhot.6b
+Berakhot 7a,"righteous, anger, wicked, exodus, mercy, sin, divine presence, prayer, world-to-come, mil, phylacteries, israelites, high priest, incense, heretic, creation, mitzvot, levites",https://www.sefaria.org.il/Berakhot.7a
+Berakhot 7b,"wicked, righteous, torah, prayer, mil, sin, gog and magog, judgment, mitzva, temple, anger, exodus, shalom, parable, mamzer, mercy, torah study, mitzvot",https://www.sefaria.org.il/Berakhot.7b
+Berakhot 8a,"torah, prayer, sin, mil, mercy, torah study, the temple, shabbat, divine presence, mitzvot, world-to-come, aramaic",https://www.sefaria.org.il/Berakhot.8a
+Berakhot 8b,"shema, torah, persian, anger, sin, phylacteries, gehenna, aramaic, the temple, mil",https://www.sefaria.org.il/Berakhot.8b
+Berakhot 9a,"paschal lamb, shema, exodus, mitzva, sin, peace-offering, torah, mitzvot, paschal offering, prayer, passover, mil",https://www.sefaria.org.il/Berakhot.9a
+Berakhot 9b,"prayer, sin, shema, mitzvot, parable, exodus, mitzva, wicked, righteous, tekhelet, torah, mil, phylacteries, world-to-come",https://www.sefaria.org.il/Berakhot.9b
+Berakhot 10a,"sin, mercy, wicked, mil, creation, heretic, prayer, gog and magog, repented, righteous, purity, anger, gehenna, torah, world-to-come, mitzva, judgment",https://www.sefaria.org.il/Berakhot.10a
+Berakhot 10b,"shema, sin, prayer, torah, mitzva, new moon, mil, exodus, torah study, mercy, temple, idol worship, the sanctuary, torah law, mitzvot, anger",https://www.sefaria.org.il/Berakhot.10b
+Berakhot 11a,"shema, sin, mitzva, sukka, torah, phylacteries, mil, parable, mitzvot, sukkot, anger",https://www.sefaria.org.il/Berakhot.11a
+Berakhot 11b,"sin, torah, shema, priest, the temple, mitzvot, high priest, prayer, shabbat, torah study, mil, temple, priestly benediction",https://www.sefaria.org.il/Berakhot.11b
+Berakhot 12a,"sin, shema, priest, prayer, heretics, torah, mil, the temple, priestly benediction, shabbat",https://www.sefaria.org.il/Berakhot.12a
+Berakhot 12b,"exodus, sin, torah, shema, righteous, mercy, the messiah, mitzva, mitzvot, prayer, priest, heretics, mil, anger, idol worship, torah law, phylacteries",https://www.sefaria.org.il/Berakhot.12b
+Berakhot 13a,"shema, torah, mitzva, nasi, sin, parable, mitzvot, exodus, gog and magog, anger, mil, jewish people, righteous",https://www.sefaria.org.il/Berakhot.13a
+Berakhot 13b,"shema, mitzva, nasi, exodus, sin, phylacteries, torah, mil, torah study",https://www.sefaria.org.il/Berakhot.13b
+Berakhot 14a,"shema, righteous, rabbinic, sin, idol worship, prayer, torah",https://www.sefaria.org.il/Berakhot.14a
+Berakhot 14b,"shema, phylacteries, sin, mitzvot, prayer, torah, mil, exodus, torah study, burnt-offering, meal-offering, peace-offering, libations",https://www.sefaria.org.il/Berakhot.14b
+Berakhot 15a,"shema, teruma, sin, mil, purity, phylacteries, torah, prayer, tithes, rabbinic law",https://www.sefaria.org.il/Berakhot.15a
+Berakhot 15b,"shema, sota, torah, mitzvot, mil, teruma, sin, mezuza, phylacteries, gehenna, a deaf-mute, an imbecile, and a minor, resurrection of the dead, priest, mitzva",https://www.sefaria.org.il/Berakhot.15b
+Berakhot 16a,"shema, sin, prayer, mitzva, torah, priest, impurity, purity, mil, rabbinic law, torah law",https://www.sefaria.org.il/Berakhot.16a
+Berakhot 16b,"prayer, shema, mil, sin, mitzva, torah, nasi, phylacteries, world-to-come, mitzvot, rabbinic law, torah law, rabbinic, garden of eden, mercy, satan",https://www.sefaria.org.il/Berakhot.16b
+Berakhot 17a,"torah, prayer, sin, mitzvot, torah study, world-to-come, mil, mercy, the temple, creation, righteous, divine presence, exodus",https://www.sefaria.org.il/Berakhot.17a
+Berakhot 17b,"shema, sin, torah, ninth of av, mil, righteous, prayer, mitzvot, shabbat, phylacteries, mitzva, mezuza",https://www.sefaria.org.il/Berakhot.17b
+Berakhot 18a,"mitzvot, torah, sin, shema, phylacteries, prayer, shabbat, mitzva, anger, righteous",https://www.sefaria.org.il/Berakhot.18a
+Berakhot 18b,"sin, wicked, torah, first temple, second temple, the temple, temple, righteous, divine presence, mil",https://www.sefaria.org.il/Berakhot.18b
+Berakhot 19a,"shema, torah, sin, mil, repented, the temple, gehenna, paschal lamb, sota, purity, rabbinic, nasi, sanhedrin, passover, impurity, judgment, satan",https://www.sefaria.org.il/Berakhot.19a
+Berakhot 19b,"torah, impurity, torah law, priest, mitzvot, rabbinic law, shema, sin, mitzva, rabbinic, nazirite, monetary law, paschal lamb, karet",https://www.sefaria.org.il/Berakhot.19b
+Berakhot 20a,"mitzva, evil eye, mitzvot, torah, sin, mil, torah study, aramaic, parable, shema",https://www.sefaria.org.il/Berakhot.20a
+Berakhot 20b,"mitzva, sin, torah law, shema, rabbinic law, torah, shabbat, prayer, mezuza, phylacteries, mitzvot, exodus, mercy, torah study, rabbinic, mil, ministering angels",https://www.sefaria.org.il/Berakhot.20b
+Berakhot 21a,"sin, shema, torah, prayer, torah law, rabbinic law, mitzva, exodus, shabbat, one who experienced a seminal emission, mil, mitzvot",https://www.sefaria.org.il/Berakhot.21a
+Berakhot 21b,"torah, prayer, mil, sin, one who experienced a seminal emission, impurity, exodus, shema, torah study, torah law, a menstruating woman",https://www.sefaria.org.il/Berakhot.21b
+Berakhot 22a,"torah, sin, impurity, one who experienced a seminal emission, shema, torah study, shalom, mil, priest, torah law",https://www.sefaria.org.il/Berakhot.22a


### PR DESCRIPTION
Add lightweight keyword extraction tool that complements the main NLP pipeline:
- Python script for frequency-based concept matching (data/create_talmud_index.py)
- Index output for 41 Talmud pages with Sefaria links (data/talmud_index_final.csv)
- Steinsaltz Talmud source data (data/steinsaltz_talmud_combined_richHTML.csv)
- Documentation explaining approach and usage (data/KEYWORD_INDEXER.md)

The indexer uses the existing talmud_concepts_gazetteer.txt to identify and rank keywords by frequency across each Talmud page. Provides quick concept analysis without requiring ML models or embeddings.